### PR TITLE
Check which shell is in use

### DIFF
--- a/local/screen
+++ b/local/screen
@@ -15,6 +15,10 @@ check_envvars() {
   log_info "CONDA_ROOT: ${CONDA_ROOT}"
 }
 
+check_shell() {
+  inspect "echo $SHELL"
+}
+
 check_tools() {
   inspect "git --version"
   inspect "aws --version"
@@ -86,6 +90,7 @@ uname_arch() {
 echo "Start screening your local environment .."
 check_platform
 check_envvars
+check_shell
 check_tools
 check_git_ssh
 check_dotfiles


### PR DESCRIPTION
Reasoned by this thread: https://nextdoor.slack.com/archives/CUZS5Q8JF/p1647627818138649

Run
```
./local/screen
```
Output as below:

For bash
```
[2022-03-21 11:38:43] which /bin/bash
/bin/bash
```

For zsh
```
[2022-03-21 11:41:30] echo /usr/local/bin/zsh
/usr/local/bin/zsh
```